### PR TITLE
Drop older FATAL_ERROR

### DIFF
--- a/_episodes/03-toplevelcmake.md
+++ b/_episodes/03-toplevelcmake.md
@@ -21,7 +21,7 @@ Start by opening the `source/CMakeLists.txt` file that contains our current CMak
 
 ~~~cmake
 # Set the minimum required CMake version:
-cmake_minimum_required( VERSION 3.4 FATAL_ERROR )
+cmake_minimum_required( VERSION 3.11 )
 ~~~
 {: .source}
 


### PR DESCRIPTION
`FATAL_ERROR` hasn't been needed since CMake 3.8 came out; this way I don't have to mention it in my course. You could also probably bump this up to 3.11 or 3.14.

By the way,

```cmake
if( NOT "$ENV{${_pp}_DIR}" STREQUAL "" )
```

could be written as:

```cmake
if( DEFINED ENV{${_pp}_DIR} )
```